### PR TITLE
Add call that will initiate a saga in bookinfo.

### DIFF
--- a/istio-microservices/bookinfo/src/details/details.rb
+++ b/istio-microservices/bookinfo/src/details/details.rb
@@ -27,6 +27,18 @@ port = Integer(ARGV[0])
 
 server = WEBrick::HTTPServer.new :BindAddress => '*', :Port => port
 
+book_details = [{
+    'id' => 0,
+    'author': 'William Shakespeare',
+    'year': 1595,
+    'type' => 'paperback',
+    'pages' => 200,
+    'publisher' => 'PublisherA',
+    'language' => 'English',
+    'ISBN-10' => '1234567890',
+    'ISBN-13' => '123-1234567890'
+}]
+
 trap 'INT' do server.shutdown end
 
 server.mount_proc '/health' do |req, res|
@@ -55,76 +67,48 @@ server.mount_proc '/details' do |req, res|
     end
 end
 
+server.mount_proc '/details/addFake' do |req, res|
+    pathParts = req.path.split('/')
+    headers = get_forward_headers(req)
+
+    begin
+        begin
+          id = Integer(pathParts[-1])
+        rescue
+          raise 'please provide numeric product id'
+        end
+        add_book_detail(id)
+        details = get_book_details(id, headers)
+        res.body = details.to_json
+        res['Content-Type'] = 'application/json'
+    rescue => error
+        res.body = {'error' => error}.to_json
+        res['Content-Type'] = 'application/json'
+        res.status = 400
+    end
+end
+
 # TODO: provide details on different books.
 def get_book_details(id, headers)
-    if ENV['ENABLE_EXTERNAL_BOOK_SERVICE'] === 'true' then
-      # the ISBN of one of Comedy of Errors on the Amazon
-      # that has Shakespeare as the single author
-        isbn = '0486424618'
-        return fetch_details_from_external_service(isbn, id, headers)
+    book_detail = book_details.select do |book|
+      book[:id] == id
     end
 
-    return {
-        'id' => id,
-        'author': 'William Shakespeare',
-        'year': 1595,
-        'type' => 'paperback',
-        'pages' => 200,
-        'publisher' => 'PublisherA',
-        'language' => 'English',
-        'ISBN-10' => '1234567890',
-        'ISBN-13' => '123-1234567890'
-    }
+    return book_detail[-1]
 end
 
-def fetch_details_from_external_service(isbn, id, headers)
-    uri = URI.parse('https://www.googleapis.com/books/v1/volumes?q=isbn:' + isbn)
-    http = Net::HTTP.new(uri.host, ENV['DO_NOT_ENCRYPT'] === 'true' ? 80:443)
-    http.read_timeout = 5 # seconds
-
-    # DO_NOT_ENCRYPT is used to configure the details service to use either
-    # HTTP (true) or HTTPS (false, default) when calling the external service to
-    # retrieve the book information.
-    #
-    # Unless this environment variable is set to true, the app will use TLS (HTTPS)
-    # to access external services.
-    unless ENV['DO_NOT_ENCRYPT'] === 'true' then
-      http.use_ssl = true
-    end
-
-    request = Net::HTTP::Get.new(uri.request_uri)
-    headers.each { |header, value| request[header] = value }
-
-    response = http.request(request)
-
-    json = JSON.parse(response.body)
-    book = json['items'][0]['volumeInfo']
-
-    language = book['language'] === 'en'? 'English' : 'unknown'
-    type = book['printType'] === 'BOOK'? 'paperback' : 'unknown'
-    isbn10 = get_isbn(book, 'ISBN_10')
-    isbn13 = get_isbn(book, 'ISBN_13')
-
-    return {
-        'id' => id,
-        'author': book['authors'][0],
-        'year': book['publishedDate'],
-        'type' => type,
-        'pages' => book['pageCount'],
-        'publisher' => book['publisher'],
-        'language' => language,
-        'ISBN-10' => isbn10,
-        'ISBN-13' => isbn13
-  }
-
-end
-
-def get_isbn(book, isbn_type)
-  isbn_dentifiers = book['industryIdentifiers'].select do |identifier|
-    identifier['type'] === isbn_type
-  end
-
-  return isbn_dentifiers[0]['identifier']
+def add_book_detail(id)
+    book_details.push({
+      'id' => id,
+      'author': rand(36**12).to_s(36),
+      'year': rand(2000),
+      'type' => rand(36**9).to_s(36),
+      'pages' => 200,
+      'publisher' => rand(36**8).to_s(36),
+      'language' => rand(36**5).to_s(36),
+      'ISBN-10' => rand(36**10).to_s(36),
+      'ISBN-13' => rand(36**13).to_s(36)
+    })
 end
 
 def get_forward_headers(request)

--- a/istio-microservices/bookinfo/src/productpage/productpage.py
+++ b/istio-microservices/bookinfo/src/productpage/productpage.py
@@ -399,7 +399,7 @@ def addFakeProductRatingAndDetails(product_id):
     """
 
     try:
-        res = requests.get("http://localhost:20000", headers={"Start-Faking": "True", "Product-Id": product_id})
+        res = requests.get("http://localhost:3001", headers={"Start-Faking": "True", "Product-Id": product_id})
         return res.status_code, res.text
     except Exception as e:
         return 500, str(e)

--- a/istio-microservices/bookinfo/src/productpage/productpage.py
+++ b/istio-microservices/bookinfo/src/productpage/productpage.py
@@ -14,7 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-
+import copy
 from __future__ import print_function
 from flask_bootstrap import Bootstrap
 from flask import Flask, request, session, render_template, redirect, url_for
@@ -93,6 +93,14 @@ service_dict = {
     "details": details,
     "reviews": reviews,
 }
+
+products = [
+    {
+        'id': 0,
+        'title': 'The Comedy of Errors',
+        'descriptionHtml': '<a href="https://en.wikipedia.org/wiki/The_Comedy_of_Errors">Wikipedia Summary</a>: The Comedy of Errors is one of <b>William Shakespeare\'s</b> early plays. It is his shortest and one of his most farcical comedies, with a major part of the humour coming from slapstick and mistaken identity, in addition to puns and word play.'
+    }
+]
 
 # A note on distributed tracing:
 #
@@ -277,7 +285,24 @@ def front():
 # The API:
 @app.route('/api/v1/products')
 def productsRoute():
-    return json.dumps(getProducts()), 200, {'Content-Type': 'application/json'}
+
+    if request.method == "POST":
+        product = {
+            "id": len(products),
+            "title": request.headers["Title"]
+            "descriptionHtml": request.text 
+        }
+
+        products.append(product)
+
+        code, response = addFakeProductRatingAndDetails(product["id"])
+        if code != 200:
+            products.pop()
+
+        return json.dumps(getProducts()), 200, {'Content-Type': 'application/json', "Product-Page-Added": "True"}
+
+    else:
+        return json.dumps(getProducts()), 200, {'Content-Type': 'application/json'}
 
 
 @app.route('/api/v1/products/<product_id>')
@@ -303,16 +328,20 @@ def ratingsRoute(product_id):
     status, ratings = getProductRatings(product_id, headers)
     return json.dumps(ratings), status, {'Content-Type': 'application/json'}
 
-
 # Data providers:
 def getProducts():
-    return [
-        {
-            'id': 0,
-            'title': 'The Comedy of Errors',
-            'descriptionHtml': '<a href="https://en.wikipedia.org/wiki/The_Comedy_of_Errors">Wikipedia Summary</a>: The Comedy of Errors is one of <b>William Shakespeare\'s</b> early plays. It is his shortest and one of his most farcical comedies, with a major part of the humour coming from slapstick and mistaken identity, in addition to puns and word play.'
-        }
-    ]
+    """ Modified to fetch ratings for all of its products """
+
+    products_with_ratings = []
+
+    for product in products:
+        new_product = copy.deepcopy(product)
+        _, product_ratings = getProductRatings(new_product["id"], {})
+        new_product["ratings"] = product_ratings
+
+        products_with_ratings.append(new_product)
+
+    return products_with_ratings
 
 
 def getProduct(product_id):
@@ -363,17 +392,17 @@ def getProductRatings(product_id, headers):
         status = res.status_code if res is not None and res.status_code else 500
         return status, {'error': 'Sorry, product ratings are currently unavailable for this book.'}
 
+def addFakeProductRatingAndDetails(product_id):
+    """
+    Let the saga transaction begin! This request should be intersected by qbox,
+    and the response should be returned from qbox
+    """
 
-class Writer(object):
-    def __init__(self, filename):
-        self.file = open(filename, 'w')
-
-    def write(self, data):
-        self.file.write(data)
-
-    def flush(self):
-        self.file.flush()
-
+    try:
+        res = requests.get("http://localhost:20000", headers={"Start-Faking": "True", "Product-Id": product_id})
+        return res.status_code, res.text
+    except Exception as e:
+        return 500, str(e)
 
 if __name__ == '__main__':
     if len(sys.argv) < 2:

--- a/istio-microservices/bookinfo/src/ratings/package.json
+++ b/istio-microservices/bookinfo/src/ratings/package.json
@@ -4,6 +4,7 @@
   },
   "dependencies": {
     "httpdispatcher": "1.0.0",
+    "faker": "4.1.0",
     "mongodb": "^2.2.31",
     "mysql": "^2.15.0"
   }

--- a/istio-microservices/bookinfo/src/reviews/reviews-application/src/main/java/application/rest/LibertyRestEndpoint.java
+++ b/istio-microservices/bookinfo/src/reviews/reviews-application/src/main/java/application/rest/LibertyRestEndpoint.java
@@ -43,7 +43,7 @@ public class LibertyRestEndpoint extends Application {
     private final static String ratings_service = "http://" + ratings_hostname + services_domain + ":9080/ratings";
     // HTTP headers to propagate for distributed tracing are documented at
     // https://istio.io/docs/tasks/telemetry/distributed-tracing/overview/#trace-context-propagation
-    private final static String[] headers_to_proagate = {"x-request-id","x-b3-traceid","x-b3-spanid","x-b3-sampled","x-b3-flags",
+    private final static String[] headers_to_propagate = {"x-request-id","x-b3-traceid","x-b3-spanid","x-b3-sampled","x-b3-flags",
       "x-ot-span-context","x-datadog-trace-id","x-datadog-parent-id","x-datadog-sampled", "end-user","user-agent"};
 
     private String getJsonResponse (String productId, int starsReviewer1, int starsReviewer2) {
@@ -93,7 +93,7 @@ public class LibertyRestEndpoint extends Application {
       Client client = cb.build();
       WebTarget ratingsTarget = client.target(ratings_service + "/" + productId);
       Invocation.Builder builder = ratingsTarget.request(MediaType.APPLICATION_JSON);
-      for (String header : headers_to_proagate) {
+      for (String header : headers_to_propagate) {
         String value = requestHeaders.getHeaderString(header);
         if (value != null) {
           builder.header(header,value);


### PR DESCRIPTION
I found that, contrary to expectations, these services are not actually
backed by databases at all. This is fine - I switched to using in-memory
data for the proof-of-concept.

The `products` service now supports a POST method to `/api/v1/products`
to add new products. This makes a request to `localhost:20000` Our
`qbox` engine on `localhost:3001` should intercept this request,
and make it easy to contact the `details` and `ratings` services to
update details and ratings accordingly.

I have not tested any of this, nor built the corresponding images. Once
this is approved, I will merge, build images, and update the
corresponding Kubernetes YAML to reference these new images.